### PR TITLE
100件（1回の取得最大件数）以上のツイート取得

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -24,10 +24,10 @@ class TweetsController < ApplicationController
           update_tweet_record(tweet, res)
         else
           create_tweet_record(res)
-          extended_entities_exist?(res["extended_entities"])
+          extended_entities_exist(res["extended_entities"])
         end
       end
-      break unless next_token_exist?(response, query_params)
+      break unless next_token_exist(response, query_params)
     end
     redirect_to tweets_path
   end
@@ -64,7 +64,7 @@ class TweetsController < ApplicationController
       )
     end
 
-    def extended_entities_exist?(extended_entities)
+    def extended_entities_exist(extended_entities)
       return unless extended_entities
 
       extended_entities["media"].each do |res_medium|
@@ -83,7 +83,7 @@ class TweetsController < ApplicationController
       @user = current_user
     end
 
-    def next_token_exist?(response, query_params)
+    def next_token_exist(response, query_params)
       return unless response["next"]
 
       query_params[:next] = response["next"]

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -35,7 +35,7 @@ class Tweet < ApplicationRecord
           date_to: datetime.strftime("%Y%m%d%H%M"),
           date_from: datetime.ago(1.year).strftime("%Y%m%d%H%M")
         }
-      when period == "until_one_year"
+      when "until_one_year"
         {
           date_to: datetime.ago(1.year).strftime("%Y%m%d%H%M"),
           date_from: datetime.ago(10.years).strftime("%Y%m%d%H%M")

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -9,9 +9,6 @@ class Tweet < ApplicationRecord
   validates :retweet_flag, inclusion: [true, false]
 
   has_many :media, dependent: :destroy
-  require "net/http"
-  require "uri"
-  require "json"
 
   class << self
     def fetch_tweet(query_params)
@@ -36,7 +33,7 @@ class Tweet < ApplicationRecord
       when "until_now"
         {
           date_to: datetime.strftime("%Y%m%d%H%M"),
-          date_from: datetime.ago(1.year).strftime("%Y%m%d%H%M")
+          date_from: datetime.ago(28.days).strftime("%Y%m%d%H%M")
         }
       when period == "until_one_year"
         {
@@ -52,7 +49,7 @@ class Tweet < ApplicationRecord
         "fromDate": query_params[:date_from].to_s,
         "toDate": query_params[:date_to].to_s
       }
-      data.merge!({ "next": query_params[:next].to_s }) unless query_params[:next].nil?
+      data.merge!({ "next": query_params[:next].to_s }) if query_params[:next]
       JSON.generate(data)
     end
 

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -9,24 +9,26 @@ class Tweet < ApplicationRecord
   validates :retweet_flag, inclusion: [true, false]
 
   has_many :media, dependent: :destroy
+  require "net/http"
+  require "uri"
+  require "json"
 
   class << self
     def twitter_search_data(query_params)
       uri = URI.parse("https://api.twitter.com/1.1/tweets/search/#{ENV['PLAN']}/#{ENV['LABEL']}.json")
-      req_options = {
-        use_ssl: uri.scheme == "https"
+      headers = { "Authorization": "Bearer #{ENV['BEARER_TOKEN']}", "Content-Type": "application/json" }
+      data = {
+        "query": "from:#{query_params[:login_user]}".to_s,
+        "fromDate": query_params[:date_from].to_s,
+        "toDate": query_params[:date_to].to_s
       }
-      response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
-        http.request(fetch_request_data(uri, query_params))
-      end
-      JSON.parse(response.body)
-    end
 
-    def fetch_request_data(uri, query_params)
-      request = Net::HTTP::Post.new(uri)
-      request["Authorization"] = "Bearer #{ENV['BEARER_TOKEN']}"
-      request.body = fetch_request_query(query_params)
-      request
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == "https"
+      request = Net::HTTP::Post.new(uri.request_uri, headers)
+      request.body = JSON.generate(data)
+      response = http.request(request)
+      JSON.parse(response.body)
     end
 
     # apiに送るクエリの取得
@@ -42,7 +44,7 @@ class Tweet < ApplicationRecord
       when "until_now"
         {
           date_to: datetime.ago(9.hours).strftime("%Y%m%d%H%M"),
-          date_from: datetime.ago(1.year).strftime("%Y%m%d%H%M")
+          date_from: datetime.ago(28.days).strftime("%Y%m%d%H%M")
         }
       when period == "until_one_year"
         {
@@ -52,13 +54,13 @@ class Tweet < ApplicationRecord
       end
     end
 
-    # クエリ指定
-    def fetch_request_query(query_params)
-      "{
-          \"query\":\"from:#{query_params[:login_user]}\",
-          \"fromDate\":\"#{query_params[:date_from]}\",
-          \"toDate\":\"#{query_params[:date_to]}\"
-      }"
+    def sent_query(query_params)
+      data = {
+        "query": "from:#{query_params[:login_user]}".to_s,
+        "fromDate": query_params[:date_from].to_s,
+        "toDate": query_params[:date_to].to_s
+      }
+      data.merge({ "next": query_params[:next].to_s }) if query_params[:next]
     end
   end
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -14,19 +14,12 @@ class Tweet < ApplicationRecord
   require "json"
 
   class << self
-    def twitter_search_data(query_params)
+    def fetch_tweet(query_params)
       uri = URI.parse("https://api.twitter.com/1.1/tweets/search/#{ENV['PLAN']}/#{ENV['LABEL']}.json")
-      headers = { "Authorization": "Bearer #{ENV['BEARER_TOKEN']}", "Content-Type": "application/json" }
-      data = {
-        "query": "from:#{query_params[:login_user]}".to_s,
-        "fromDate": query_params[:date_from].to_s,
-        "toDate": query_params[:date_to].to_s
-      }
-
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = uri.scheme == "https"
+      headers = fetch_headers
+      http = http_settings(uri)
       request = Net::HTTP::Post.new(uri.request_uri, headers)
-      request.body = JSON.generate(data)
+      request.body = sent_query(query_params)
       response = http.request(request)
       JSON.parse(response.body)
     end
@@ -34,8 +27,8 @@ class Tweet < ApplicationRecord
     # apiに送るクエリの取得
     def fetch_query_params(form_params)
       date_query = period_params(form_params[:period])
-      query_params = form_params.merge!(date_query)
-      query_params.merge!({ next: nil })
+      form_params.merge!(date_query)
+      # query_params.merge!({ next: nil })
     end
 
     def period_params(period)
@@ -44,7 +37,7 @@ class Tweet < ApplicationRecord
       when "until_now"
         {
           date_to: datetime.ago(9.hours).strftime("%Y%m%d%H%M"),
-          date_from: datetime.ago(28.days).strftime("%Y%m%d%H%M")
+          date_from: datetime.ago(1.year).strftime("%Y%m%d%H%M")
         }
       when period == "until_one_year"
         {
@@ -60,7 +53,21 @@ class Tweet < ApplicationRecord
         "fromDate": query_params[:date_from].to_s,
         "toDate": query_params[:date_to].to_s
       }
-      data.merge({ "next": query_params[:next].to_s }) if query_params[:next]
+      data.merge!({ "next": query_params[:next].to_s }) unless query_params[:next].nil?
+      JSON.generate(data)
+    end
+
+    def fetch_headers
+      {
+        "Authorization": "Bearer #{ENV['BEARER_TOKEN']}",
+        "Content-Type": "application/json"
+      }
+    end
+
+    def http_settings(uri)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == "https"
+      http
     end
   end
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -33,7 +33,7 @@ class Tweet < ApplicationRecord
       when "until_now"
         {
           date_to: datetime.strftime("%Y%m%d%H%M"),
-          date_from: datetime.ago(28.days).strftime("%Y%m%d%H%M")
+          date_from: datetime.ago(1.year).strftime("%Y%m%d%H%M")
         }
       when period == "until_one_year"
         {


### PR DESCRIPTION
Closes #31 

## 目的・概要
<!--  プルリクエストの目的・概要を記載  -->
1回の最大取得件数が100件のため、指定期間内に100件以上ツイートがあった場合、取得漏れが生じるのを改善

## 実装内容
<!-- 実装の技術的な内容を箇条書きで記載 -->
- 1回目のレスポンス取得時の"next"パラメータを用いて次の100件を新たにリクエスト
- ひろみちさんのコードを参考に、クエリのパラメータ形式をハッシュにて指定

## 稼働確認チェック
- [x] ローカル環境での動作確認
- [x] rspecの実行＆エラーなし
- [x] rubocopの実行＆コード修正

- 個人アカウントにて去年の12/12までのツイート取得確認（300件以上前)

- indexページにて20ページ表示、200件ツイートがテーブルに格納されていること確認
<img width="544" alt="20ページ" src="https://user-images.githubusercontent.com/35606852/101419582-a6d4a080-3933-11eb-86ab-8ff5fb5fe4ea.png">

## 参考資料
- [ひろみちさんのコード](https://github.com/great084/twitter_tool/wiki/%E3%82%B5%E3%83%B3%E3%83%97%E3%83%AB%E3%82%B3%E3%83%BC%E3%83%89(Twitter-API))

- [twitter developer](https://developer.twitter.com/en/docs/twitter-api/v1/tweets/search/api-reference/premium-search#Pagination)

## 連絡事項
<!-- 本プルリク反映後に運用変更が必要になる場合など記載 -->
特になし