### PR TITLE
oauth認証のアクセストークン,シークレットをDBに格納

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,8 +9,7 @@ class SessionsController < ApplicationController
   def create
     user_data = request.env["omniauth.auth"]
     if user_data[:uid]
-      user = User.find_or_initialize_by(uid: user_data[:uid])
-      user.update(nickname: user_data[:info][:nickname])
+      user = user_table_update(user_data)
       log_in(user)
     else
       flash[:alert] = "ログインできませんでした。もう一度ログインしてください"
@@ -21,5 +20,15 @@ class SessionsController < ApplicationController
   def destroy
     log_out if logged_in?
     redirect_to root_url
+  end
+
+  def user_table_update(user_data)
+    user = User.find_or_initialize_by(uid: user_data[:uid])
+    user.update(
+      nickname: user_data[:info][:nickname],
+      token: user_data.credentials.token,
+      secret: user_data.credentials.secret
+    )
+    user
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,8 +26,8 @@ class SessionsController < ApplicationController
     user = User.find_or_initialize_by(uid: user_data[:uid])
     user.update(
       nickname: user_data[:info][:nickname],
-      token: user_data.credentials.token,
-      secret: user_data.credentials.secret
+      token: user_data[:credentials][:token],
+      secret: user_data[:credentials][:secret]
     )
     user
   end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -32,7 +32,6 @@ class Tweet < ApplicationRecord
     # apiに送るクエリの取得
     def fetch_query_params(form_params)
       date_query = period_params(form_params[:period])
-      binding.pry
       query_params = form_params.merge!(date_query)
       query_params.merge!({ next: nil })
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   validates :uid, presence: true
   validates :nickname, presence: true
+  validates :token, presence: true
+  validates :secret, presence: true
   has_many :tweets, dependent: :destroy
 end

--- a/db/migrate/20201210132308_add_token_and_secret_to_users.rb
+++ b/db/migrate/20201210132308_add_token_and_secret_to_users.rb
@@ -1,0 +1,8 @@
+class AddTokenAndSecretToUsers < ActiveRecord::Migration[6.0]
+  def change
+    change_table :users, bulk: true do |t|
+      t.string :token
+      t.string :secret
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_18_234531) do
+ActiveRecord::Schema.define(version: 2020_12_10_132308) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,8 @@ ActiveRecord::Schema.define(version: 2020_11_18_234531) do
     t.string "nickname"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "token"
+    t.string "secret"
   end
 
   add_foreign_key "media", "tweets"


### PR DESCRIPTION
closes #23 

## 目的・概要
<!--  プルリクエストの目的・概要を記載  -->
Twitterの投稿を行う場合、twitterユーザのアクセストークンが必要となるため、
認証時にtoken, secretを取得し、DBに保存する

## 実装内容
<!-- 実装の技術的な内容を箇条書きで記載 -->
- usersテーブルにtoken, secretカラム追加
- request.envからtoken ,secret取得
- ログイン時にUsersテーブルへtoken, secretを格納

## 稼働確認チェック
- [x] ローカル環境での動作確認
- [x] rspecの実行＆エラーなし
- [x] rubocopの実行＆コード修正

## 参考資料
- https://qiita.com/gin0606/items/9f71645d485249684e9f

## 動作確認
<!-- 本プルリク反映後に運用変更が必要になる場合など記載 -->
- 動作確認前に、`rails db:migrate`が必要

- rails consoleにて
 1回目のログイン前はtoken, secret = nil, 
 1回ログイン後は、token, secret共に文字列のトークンが入っています