### PR TITLE
carrierwaveを呼んでいる不要なコードを削除

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,6 +1,0 @@
-class ImageUploader < CarrierWave::Uploader::Base
-  storage :file
-  def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  end
-end


### PR DESCRIPTION
## 目的・概要
<!--  プルリクエストの目的・概要を記載  -->
Herokuへデプロしてビルドした際に、以下のエラーが発生した

```
1: from /app/vendor/bundle/ruby/2.6.0/gems/bootsnap-1.4.9/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
/app/app/uploaders/image_uploader.rb:1:in `<main>': uninitialized constant CarrierWave (NameError)
```
原因はcarrierwaveのgemをインストールしていないにもかかわらず、carrierwaveのソースを呼んでいるため。
現状不要なコードであるため削除する

## 実装内容
<!-- 実装の技術的な内容を箇条書きで記載 -->
- app/uploaders/image_uploader.rb の削除

## UI変更概要
<!-- UIの変更内容を大まかに記載 -->
なし

## 稼働確認チェック
- [x] ローカル環境での動作確認
- [x] rspecの実行＆エラーなし
- [x] rubocopの実行＆コード修正

## 参考資料
なし

## 連絡事項
<!-- 本プルリク反映後に運用変更が必要になる場合など記載 -->
