### PR TITLE
[機能追加]選択した投稿を再投稿する 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,20 +2,20 @@
 # 追加した規約ファイルを読み込み
 require:
   - rubocop-rails
-  
+
 AllCops:
   TargetRubyVersion: 2.6
-  NewCops: enable    # ← 新しい規約が登録された場合に、適用するかどうかの判定
-  Exclude:           # 自動生成・初期作成ファイル、およびロジックとは無関係のファイル（ex. Gemfile, spec関連）は除外
-    - 'bin/**'
-    - 'node_modules/**/*'
-    - 'config/**/*'
-    - 'config.ru'
-    - 'db/schema.rb'
-    - 'db/seeds.rb'
-    - 'Gemfile'
-    - 'spec/rails_helper.rb'
-  
+  NewCops: enable # ← 新しい規約が登録された場合に、適用するかどうかの判定
+  Exclude: # 自動生成・初期作成ファイル、およびロジックとは無関係のファイル（ex. Gemfile, spec関連）は除外
+    - "bin/**"
+    - "node_modules/**/*"
+    - "config/**/*"
+    - "config.ru"
+    - "db/schema.rb"
+    - "db/seeds.rb"
+    - "Gemfile"
+    - "spec/rails_helper.rb"
+
 # 日本語でのコメントを許可
 Style/AsciiComments:
   Enabled: false
@@ -32,9 +32,12 @@ Style/FrozenStringLiteralComment:
 # テストコード, migrate文は除外
 Metrics/MethodLength:
   Max: 20
-  Exclude: 
-    - 'spec/**/*'
-    - 'db/migrate/*'
+  Exclude:
+    - "spec/**/*"
+    - "db/migrate/*"
+# 1ファイルの行数制限を無視
+Metrics/ClassLength:
+  Enabled: false
 
 # private/protected は一段深くインデントする
 Layout/IndentationConsistency:
@@ -42,18 +45,18 @@ Layout/IndentationConsistency:
 
 # Block内の最大行数。テストコードは除外
 Metrics/BlockLength:
-  Exclude: 
-    - 'spec/**/*'
+  Exclude:
+    - "spec/**/*"
 
 # 変数・メソッドに数字はNG。テストコードは除外
 Naming/VariableNumber:
-  Exclude: 
-    - 'spec/**/*'
+  Exclude:
+    - "spec/**/*"
 
 # helper内のインスタンス変数利用は不可だが、session_helperのみ許可
 Rails/HelperInstanceVariable:
-  Exclude: 
-    - 'app/helpers/sessions_helper.rb'
+  Exclude:
+    - "app/helpers/sessions_helper.rb"
 
 # hash内のインデント設定。defaultの'special_inside_parentheses'は見づらいため変更
 Layout/FirstHashElementIndentation:
@@ -62,3 +65,6 @@ Layout/FirstHashElementIndentation:
 # 文字列の囲み文字はダブルクオートを使う
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+#メソッドの複雑性の制限解除
+Metrics/AbcSize:
+  Enabled: false

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -72,3 +72,8 @@ table {
     height: 80px;
   }
 }
+// 再投稿モーダル
+.mordal-image{
+  width:150px;
+  height:150px;
+}

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -145,11 +145,12 @@ class TweetsController < ApplicationController
         config.access_token = current_user.token
         config.access_token_secret = current_user.secret
       end
-      def error_status?(res_status)
-        !!if res_status[:code] != "200"
-            flash[:alert] = "以下の理由でツイートを取得できませんでした。#{res_status[:message]}"
-            redirect_to new_tweet_path
-          end
-      end
+    end
+
+    def error_status?(res_status)
+      !!if res_status[:code] != "200"
+          flash[:alert] = "以下の理由でツイートを取得できませんでした。#{res_status[:message]}"
+          redirect_to new_tweet_path
+        end
     end
 end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -54,13 +54,6 @@ class TweetsController < ApplicationController
   def post_create
     # 再投稿する
     @tweet = Tweet.new(post_params)
-    if @tweet.text.blank?
-      flash[:alert] = "空欄で投稿はできません。"
-      render :post_new
-    elsif @tweet.text.length >= 140
-      flash[:alert] = "140字以内で投稿してください"
-      render :post_new
-    else
       if @client.update("#{@tweet.text}\r")
         # 再投稿フラッグをtrueにする
         @tweet_data_all = Tweet.find(params[:id])
@@ -72,7 +65,6 @@ class TweetsController < ApplicationController
         flash[:alert] = "再投稿できませんでした"
         render :post_new
       end
-    end
   end
 
   private

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -54,10 +54,6 @@ class TweetsController < ApplicationController
     redirect_to new_tweet_path
   end
 
-  def post_new
-    @tweet = Tweet.find(params[:id])
-  end
-
   def post_create
     # 再投稿する
     @tweet = Tweet.new(post_params)

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -65,6 +65,7 @@ class TweetsController < ApplicationController
         flash[:alert] = "再投稿できませんでした"
         render :post_new
       end
+
   end
 
   private
@@ -131,8 +132,8 @@ class TweetsController < ApplicationController
       @client = Twitter::REST::Client.new do |config|
         config.consumer_key = ENV["TWITTER_API_KEY"]
         config.consumer_secret = ENV["TWITTER_API_SECRET"]
-        config.access_token = ENV["TWITTER_ACCESS_TOKEN"]
-        config.access_token_secret = ENV["ACCESS_TOKEN_SECRET"]
+        config.access_token = current_user.token
+        config.access_token_secret = current_user.secret
       end
     end
 end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -45,7 +45,7 @@ class TweetsController < ApplicationController
     @tweet_data_all = Tweet.find(params[:id])
     @tweet_data_all.tweet_flag = true
     @tweet_data_all.save
-    redirect_to tweet_path(@tweet_data_all),success: "再投稿に成功しました"
+    redirect_to tweet_path(@tweet_data_all), success: "再投稿に成功しました"
   rescue StandardError => e
     redirect_to tweet_path(@tweet_data_all), danger: "再投稿に失敗しました#{e}"
   end
@@ -134,6 +134,7 @@ class TweetsController < ApplicationController
         config.access_token_secret = current_user.secret
       end
     end
+
     def params_retweet
       params.require(:tweet).permit(:add_comments, :tweet_id)
     end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -52,10 +52,18 @@ class TweetsController < ApplicationController
   end
 
   def post_create
+    # 再投稿する
     @tweet = Tweet.new(post_params)
-    # \rで改行する
     @client.update("#{@tweet.text}\r")
-    redirect_to root_path
+    if @client.update("#{@tweet.text}\r")
+      @tweet_flag = Tweet.find(params[:id])
+      @tweet_flag.tweet_flag = true
+      @tweet_flag.save
+      redirect_to root_path
+    else
+      flash[:alert] = "再投稿できませんでした"
+      redirect_to tweet_path(@tweet_flag)
+    end
   end
 
   private

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -54,15 +54,25 @@ class TweetsController < ApplicationController
   def post_create
     # 再投稿する
     @tweet = Tweet.new(post_params)
-    @client.update("#{@tweet.text}\r")
-    if @client.update("#{@tweet.text}\r")
-      @tweet_flag = Tweet.find(params[:id])
-      @tweet_flag.tweet_flag = true
-      @tweet_flag.save
-      redirect_to root_path
+    if @tweet.text.blank?
+      flash[:alert] = "空欄で投稿はできません。"
+      render :post_new
+    elsif @tweet.text.length >= 140
+      flash[:alert] = "140字以内で投稿してください"
+      render :post_new
     else
-      flash[:alert] = "再投稿できませんでした"
-      redirect_to tweet_path(@tweet_flag)
+      @client.update("#{@tweet.text}\r")
+      if @client.update("#{@tweet.text}\r")
+        # 再投稿フラッグをtrueにする
+        @tweet_flag = Tweet.find(params[:id])
+        @tweet_flag.tweet_flag = true
+        @tweet_flag.save
+        redirect_to tweet_path(@tweet_flag)
+        flash[:alert] = "再投稿しました"
+      else
+        flash[:alert] = "再投稿できませんでした"
+        render :post_new
+      end
     end
   end
 

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -54,6 +54,10 @@ class TweetsController < ApplicationController
   def post_create
     # 再投稿する
     @tweet = Tweet.new(post_params)
+    if @tweet.text.length >= 140
+      flash[:alert] = "140字以内で投稿してください"
+      render :post_new
+    else
       if @client.update("#{@tweet.text}\r")
         # 再投稿フラッグをtrueにする
         @tweet_data_all = Tweet.find(params[:id])
@@ -65,7 +69,7 @@ class TweetsController < ApplicationController
         flash[:alert] = "再投稿できませんでした"
         render :post_new
       end
-
+    end
   end
 
   private

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -61,13 +61,12 @@ class TweetsController < ApplicationController
       flash[:alert] = "140字以内で投稿してください"
       render :post_new
     else
-      @client.update("#{@tweet.text}\r")
       if @client.update("#{@tweet.text}\r")
         # 再投稿フラッグをtrueにする
-        @tweet_flag = Tweet.find(params[:id])
-        @tweet_flag.tweet_flag = true
-        @tweet_flag.save
-        redirect_to tweet_path(@tweet_flag)
+        @tweet_data_all = Tweet.find(params[:id])
+        @tweet_data_all.tweet_flag = true
+        @tweet_data_all.save
+        redirect_to tweet_path(@tweet_data_all)
         flash[:alert] = "再投稿しました"
       else
         flash[:alert] = "再投稿できませんでした"
@@ -128,7 +127,7 @@ class TweetsController < ApplicationController
 
     def response_data_nil?(response)
       !!if response["results"].empty?
-          redirect_to new_tweet_path, flash: { aler: "指定した期間内にデータはありませんでした。" }
+          redirect_to new_tweet_path, flash: { alert: "指定した期間内にデータはありませんでした。" }
         end
     end
 

--- a/app/views/tweets/_tweet_modal.html.erb
+++ b/app/views/tweets/_tweet_modal.html.erb
@@ -3,7 +3,7 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="label1">リツイートする</h5>
+        <h5 class="modal-title" id="label1">再投稿する</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>

--- a/app/views/tweets/_tweet_modal.html.erb
+++ b/app/views/tweets/_tweet_modal.html.erb
@@ -1,0 +1,32 @@
+<div class="modal fade" id="modal1" tabindex="-1"
+      role="dialog" aria-labelledby="label1" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="label1">リツイートする</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <%= form_with model: @tweet,method: :post, url: "/tweets/#{params[:id]}/post_create", local:true do |f| %>
+        <div class="modal-body">
+          <div class="p-2">
+            <p><%= f.label :label_old_tweet, "元投稿内容" %></p>
+            <p><%= f.text_area  :text,maxlength: 140 ,:required => true, class: "form-control", rows: 4, value: @tweet.text %></p>
+          </div>
+          <div class="p-2">
+            <p><%= f.label :label_show_image, "画像" %></p>
+            <% @tweet.media.each do |media| %>
+              <%= image_tag media.media_url.to_s,class: "mordal-image "  %>
+            <% end %>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+          <%= f.hidden_field :tweet_id, value: @tweet.tweet_id %>
+          <%= f.submit "再投稿する", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/tweets/post_new.html.erb
+++ b/app/views/tweets/post_new.html.erb
@@ -1,7 +1,0 @@
-  <h2><%= flash.now[:alert] %></h2>
-
-<%= form_with model: @tweet,method: :post, url: "/tweets/#{params[:id]}/post_create", local:true do |f| %>
- <div><%= f.text_area :text,maxlength: 140 ,:required => true%></div>
-  <div><%= f.submit %></div>
-<% end %>
-

--- a/app/views/tweets/post_new.html.erb
+++ b/app/views/tweets/post_new.html.erb
@@ -1,0 +1,4 @@
+<%= form_with model: @tweet,method: :post, url: "/tweets/#{params[:id]}/post_create", local:true do |f| %>
+ <div><%= f.text_area :text %></div>
+  <div><%= f.submit %></div>
+<% end %>

--- a/app/views/tweets/post_new.html.erb
+++ b/app/views/tweets/post_new.html.erb
@@ -1,4 +1,7 @@
+  <h2><%= flash.now[:alert] %></h2>
+
 <%= form_with model: @tweet,method: :post, url: "/tweets/#{params[:id]}/post_create", local:true do |f| %>
  <div><%= f.text_area :text %></div>
   <div><%= f.submit %></div>
 <% end %>
+

--- a/app/views/tweets/post_new.html.erb
+++ b/app/views/tweets/post_new.html.erb
@@ -1,7 +1,7 @@
   <h2><%= flash.now[:alert] %></h2>
 
 <%= form_with model: @tweet,method: :post, url: "/tweets/#{params[:id]}/post_create", local:true do |f| %>
- <div><%= f.text_area :text %></div>
+ <div><%= f.text_area :text,maxlength: 140 ,:required => true%></div>
   <div><%= f.submit %></div>
 <% end %>
 

--- a/app/views/tweets/show.html.erb
+++ b/app/views/tweets/show.html.erb
@@ -25,5 +25,5 @@
 
  <div class="text-center ">
   <%= link_to '再投稿する', "#" ,class: "btn btn-warning mx-2" %>
-  <%= link_to '再投稿する', "#",class: "btn btn-info mx-2" %>
+  <%= link_to '再投稿する', post_new_tweet_path,class: "btn btn-info mx-2" %>
  </div>

--- a/app/views/tweets/show.html.erb
+++ b/app/views/tweets/show.html.erb
@@ -1,3 +1,4 @@
+<h2><%= flash.now[:alert] %></h2>
 <h1 class="text-center">過去投稿の詳細</h1>
 <table class="table table-bordered  my-5 mx-auto table-show ">
   <tbody >

--- a/app/views/tweets/show.html.erb
+++ b/app/views/tweets/show.html.erb
@@ -25,6 +25,10 @@
 </table>
 
  <div class="text-center ">
-  <%= link_to '再投稿する', post_new_tweet_path, class: "btn btn-warning mx-2" %>
+   <button type="button" class="btn btn-warning " data-toggle="modal" data-target="#modal1" value=@tweet>
+   再投稿する
+  </button>
+  <%= render 'tweet_modal' %>
+  <%# <%= link_to '再投稿する', post_new_tweet_path, class: "btn btn-warning mx-2" %> 
   <%= link_to 'リツイートする',"#" ,class: "btn btn-info mx-2" %>
  </div>

--- a/app/views/tweets/show.html.erb
+++ b/app/views/tweets/show.html.erb
@@ -24,6 +24,6 @@
 </table>
 
  <div class="text-center ">
-  <%= link_to '再投稿する', "#" ,class: "btn btn-warning mx-2" %>
-  <%= link_to '再投稿する', post_new_tweet_path,class: "btn btn-info mx-2" %>
+  <%= link_to '再投稿する', post_new_tweet_path, class: "btn btn-warning mx-2" %>
+  <%= link_to 'リツイートする',"#" ,class: "btn btn-info mx-2" %>
  </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,12 @@ Rails.application.routes.draw do
   get '/auth/failure', to: 'sessions#failure'
   get '/logout', to: 'sessions#destroy'
   post '/tweets/search', to: 'tweets#search'
-  resources :tweets, only: [:new, :index,:show]
+  resources :tweets, only: [:new, :index,:show] do
+    member do
+      get "post_new"
+      post "post_create"
+    end
+  end
+
   root to: "users#index"
 end


### PR DESCRIPTION
closes  #39 
## 目的・概要
<!--  プルリクエストの目的・概要を記載  -->
選択した投稿を再投稿する機能を実装

## 実装内容
<!-- 実装の技術的な内容を箇条書きで記載 -->
- 再投稿ボタンを押すと、再投稿編集ページに移動
- 再投稿編集ページで編集後、投稿ボタンを押すと再投稿完了
- 再投稿できたら、再投稿フラッグをtrueに変更
- 140字以上の投稿、空欄投稿の場合の例外処理実装
## UI変更概要
<!-- UIの変更内容を大まかに記載 -->
-  再投稿編集ページ、投稿詳細ページでアラート文追加

## 稼働確認チェック
- [x] ローカル環境での動作確認
- [x] rspecの実行＆エラーなし
- [x] rubocopの実行＆コード修正

## 参考資料
-[Rubyで簡単なTwitter クライアントをつくる](https://qiita.com/shimisunet/items/c3a0b93fb13fa82ed8be)
## 連絡事項

- 画像投稿は実装できていません
- モーダル表示になっていません
- rubocopでtweetコントローラ、post_createアクションが長いと注意されていますが、最後に修正しようかなと考えています。