### PR TITLE
APIレスポンスエラー時の表示処理

### DIFF
--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -17,8 +17,7 @@ class Tweet < ApplicationRecord
       http = http_settings(uri)
       request = Net::HTTP::Post.new(uri.request_uri, headers)
       request.body = sent_query(query_params)
-      response = http.request(request)
-      JSON.parse(response.body)
+      http.request(request)
     end
 
     # apiに送るクエリの取得
@@ -64,6 +63,22 @@ class Tweet < ApplicationRecord
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme == "https"
       http
+    end
+
+    def status_in_code(response)
+      statuses =
+        { code: "200", message: "データの取得に成功しました。" },
+        { code: "400", message: "リクエストが不正です。" },
+        { code: "401", message: "アクセスには認証が必要です。" },
+        { code: "403", message: "このリソースへのアクセスは許可されておりません。" },
+        { code: "404", message: "リソースが見つかりませんでした。URLが間違っている可能性があります。" },
+        { code: "422", message: "入力値が無効です。" },
+        { code: "429", message: "アプリのリクエスト回数上限を超えました。" },
+        { code: "500", message: "サーバ内部でエラーが発生しました。" },
+        { code: "502", message: "ゲートウェイが不正です。プロキシサーバのエラーです。" },
+        { code: "503", message: "メンテナンス中です。アプリは利用できません。" }
+      res_status = statuses.select { |status| status[:code] == response.code }
+      res_status[0]
     end
   end
 end


### PR DESCRIPTION
closes #41 

## 目的・概要
<!--  プルリクエストの目的・概要を記載  -->
APIレスポンスエラー時、システムエラーが表示されることを改善

## 実装内容
<!-- 実装の技術的な内容を箇条書きで記載 -->
- レスポンスのHTTPステータスコード によって、成功か失敗かを判断
- 失敗の場合、期間指定画面にてレスポンスエラーの内容を表示

## UI変更概要
<!-- UIの変更内容を大まかに記載 -->
- エラー内容を期間指定画面に表示



### 画面キャプチャ
<!-- UIの変更後の画像を入れる（UIに変更があった場合） -->
<img width="1002" alt="エラー表示" src="https://user-images.githubusercontent.com/35606852/102416000-77f9b100-403c-11eb-8bc7-d8fd3184bcb0.png">


## 稼働確認チェック
- [x] ローカル環境での動作確認
- [x] rspecの実行＆エラーなし
- [x] rubocopの実行＆コード修正

- 稼働確認

1. ベアラートークン 不正時　  401内容表示
2. APIエンドポイント不正時　404内容表示
3. 指定日付不正時　　　　　  422内容表示

## 参考資料
- https://developer.twitter.com/en/docs/twitter-api/premium/search-api/api-reference/premium-search#HTTPCodes
- https://ja.wikipedia.org/wiki/HTTP%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%89

## 連絡事項
<!-- 本プルリク反映後に運用変更が必要になる場合など記載 -->
