### PR TITLE
Basic認証(本番用）の設定追加

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -3,3 +3,7 @@ TWITTER_API_SECRET = (各々のAPI key secretを入力)
 BEARER_TOKEN = (developerアカウントにて作成した各々のベアラートークンを入力)
 PLAN = 30day or fullarchive
 LABEL = 30day, fullarchiveのプラン作成時に設定した名前
+
+# 本番環境のみ設定
+BASIC_AUTH_USERNAME = Basic認証のユーザネーム
+BASIC_AUTH_PASSWORD = Basic認証のパスワード

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,7 @@
 class ApplicationController < ActionController::Base
   include SessionsHelper
+  if Rails.env.production?
+    http_basic_authenticate_with name: ENV["BASIC_AUTH_USERNAME"],
+                                 password: ENV["BASIC_AUTH_PASSWORD"]
+  end
 end


### PR DESCRIPTION
## 目的・概要
<!--  プルリクエストの目的・概要を記載  -->
herokuでBASIC認証を追加するための設定を追加

## 実装内容
<!-- 実装の技術的な内容を箇条書きで記載 -->
- 本番環境の場合、BASIC認証を行う

## UI変更概要
<!-- UIの変更内容を大まかに記載 -->
なし

## 稼働確認チェック
- [x] ローカル環境での動作確認
- [x] rspecの実行＆エラーなし
- [x] rubocopの実行＆コード修正
- [x] 本番環境(heroku)での稼働確認

## 参考資料
- https://qiita.com/KazuyaHara/items/f0f6c2efd6414f2f88f7

## 連絡事項
<!-- 本プルリク反映後に運用変更が必要になる場合など記載 -->
本番環境の場合のみ、環境変数に設定されたuser, passwordの認証が必要となる