### PR TITLE
[機能追加]リツイート、再投稿した日時を表示させる 機能追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,11 @@ table {
       height: 50px;
       font-size: small;
     }
+    .flag-btn-add-date {
+      width: 300px;
+      height: 50px;
+      font-size: small;
+    }
   }
 // ナビゲーションメニュー
 .navbar-dark .navbar-nav .nav-link{

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -46,6 +46,7 @@ class TweetsController < ApplicationController
     @tweet_data_all = Tweet.find(params[:id])
     @tweet_data_all.tweet_flag = true
     @tweet_data_all.save
+    Repost.create!(tweet_id: @tweet_data_all.id)
     redirect_to tweet_path(@tweet_data_all), success: "再投稿に成功しました"
   rescue StandardError => e
     redirect_to tweet_path(@tweet_data_all), danger: "再投稿に失敗しました#{e}"
@@ -55,6 +56,7 @@ class TweetsController < ApplicationController
     tweet = Tweet.find_by(tweet_string_id: params_retweet[:tweet_string_id])
     Tweet.post_add_comment_retweet(params_retweet, current_user)
     tweet.update(retweet_flag: true)
+    Retweet.create!(tweet_id: tweet.id)
     redirect_to tweet_path(tweet), success: "リツイートに成功しました"
   rescue StandardError => e
     redirect_to tweet_path(tweet), danger: "リツイートに失敗しました #{e}"
@@ -105,10 +107,6 @@ class TweetsController < ApplicationController
         tweet_id: Tweet.last.id,
         media_url: res_medium["media_url"]
       )
-    end
-
-    def create_again_tweet_record(tid)
-
     end
 
     def form_params

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -53,13 +53,13 @@ class TweetsController < ApplicationController
   end
 
   def retweet
-    tweet = Tweet.find_by(tweet_string_id: params_retweet[:tweet_string_id])
+    @tweet = Tweet.find_by(tweet_string_id: params_retweet[:tweet_string_id])
     Tweet.post_add_comment_retweet(params_retweet, current_user)
-    tweet.update(retweet_flag: true)
-    Retweet.create!(tweet_id: tweet.id)
-    redirect_to tweet_path(tweet), success: "リツイートに成功しました"
+    @tweet.update(retweet_flag: true)
+    Retweet.create!(tweet_id: @tweet.id)
+    redirect_to tweet_path(@tweet), success: "リツイートに成功しました"
   rescue StandardError => e
-    redirect_to tweet_path(tweet), danger: "リツイートに失敗しました #{e}"
+    redirect_to tweet_path(@tweet), danger: "リツイートに失敗しました #{e}"
   end
 
   private

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -52,7 +52,7 @@ class TweetsController < ApplicationController
   end
 
   def retweet
-    tweet = Tweet.find_by(tweet_id: params_retweet[:tweet_id])
+    tweet = Tweet.find_by(tweet_string_id: params_retweet[:tweet_string_id])
     Tweet.post_add_comment_retweet(params_retweet, current_user)
     tweet.update(retweet_flag: true)
     redirect_to tweet_path(tweet), success: "リツイートに成功しました"
@@ -64,7 +64,7 @@ class TweetsController < ApplicationController
 
     def create_records(response)
       response["results"].each do |res|
-        tweet = Tweet.find_by(tweet_id: res["id_str"])
+        tweet = Tweet.find_by(tweet_string_id: res["id_str"])
         if tweet
           update_tweet_record(tweet, res)
         else
@@ -78,7 +78,7 @@ class TweetsController < ApplicationController
       Tweet.create!(
         user_id: current_user.id,
         tweet_created_at: res["created_at"],
-        tweet_id: res["id_str"],
+        tweet_string_id: res["id_str"],
         text: res["text"],
         retweet_count: res["retweet_count"],
         favorite_count: res["favorite_count"]
@@ -105,6 +105,10 @@ class TweetsController < ApplicationController
         tweet_id: Tweet.last.id,
         media_url: res_medium["media_url"]
       )
+    end
+
+    def create_again_tweet_record(tid)
+
     end
 
     def form_params
@@ -137,7 +141,7 @@ class TweetsController < ApplicationController
     end
 
     def params_retweet
-      params.require(:tweet).permit(:add_comments, :tweet_id)
+      params.require(:tweet).permit(:add_comments, :tweet_string_id)
     end
 
     def error_status?(res_status)

--- a/app/helpers/tweets_helper.rb
+++ b/app/helpers/tweets_helper.rb
@@ -1,2 +1,7 @@
 module TweetsHelper
+  def again_post_date(table)
+    binding.pry
+    latest_date = table.last.created_at
+    "#{latest_date.year}年#{latest_date.month}月#{latest_date.day}日"
+  end
 end

--- a/app/helpers/tweets_helper.rb
+++ b/app/helpers/tweets_helper.rb
@@ -1,6 +1,5 @@
 module TweetsHelper
   def again_post_date(table)
-    binding.pry
     latest_date = table.last.created_at
     "#{latest_date.year}年#{latest_date.month}月#{latest_date.day}日"
   end

--- a/app/models/repost.rb
+++ b/app/models/repost.rb
@@ -1,0 +1,2 @@
+class Repost < ApplicationRecord
+end

--- a/app/models/retweet.rb
+++ b/app/models/retweet.rb
@@ -1,0 +1,2 @@
+class Retweet < ApplicationRecord
+end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -8,6 +8,8 @@ class Tweet < ApplicationRecord
   validates :tweet_flag, inclusion: [true, false]
   validates :retweet_flag, inclusion: [true, false]
   has_many :media, dependent: :destroy
+  has_many :retweets, dependent: :destroy
+  has_many :reposts, dependent: :destroy
   class << self
     def fetch_tweet(query_params)
       uri = URI.parse("https://api.twitter.com/1.1/tweets/search/#{ENV['PLAN']}/#{ENV['LABEL']}.json")

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,7 +1,7 @@
 class Tweet < ApplicationRecord
   belongs_to :user
   validates :tweet_created_at, presence: true
-  validates :tweet_id, presence: true
+  validates :tweet_string_id, presence: true
   validates :text, presence: true
   validates :retweet_count, presence: true
   validates :favorite_count, presence: true
@@ -96,7 +96,7 @@ class Tweet < ApplicationRecord
 
     def post_add_comment_retweet(params_retweet, user)
       client = twitter_client(user)
-      old_tweet_url = "https://twitter.com/#{user.nickname}/status/#{params_retweet[:tweet_id]}"
+      old_tweet_url = "https://twitter.com/#{user.nickname}/status/#{params_retweet[:tweet_string_id]}"
       client.update("#{params_retweet[:add_comments]}  #{old_tweet_url}")
     end
   end

--- a/app/views/tweets/_flag_btn_add_post_time.html.erb
+++ b/app/views/tweets/_flag_btn_add_post_time.html.erb
@@ -1,0 +1,12 @@
+<td >
+  <% if tweet.retweet_flag? %>
+    <button class="btn btn-info m-2 flag-btn-add-date" disabled>
+      最新リツイート &emsp; <%= again_post_date(@tweet.retweets) %>
+    </button>
+  <% end %>
+  <% if tweet.tweet_flag? %>
+    <button class="btn btn-warning m-2 flag-btn-add-date" disabled>
+      最新再投稿 &emsp; <%= again_post_date(@tweet.reposts) %>
+    </button>
+  <% end %>
+</td>

--- a/app/views/tweets/_flag_btn_add_post_time.html.erb
+++ b/app/views/tweets/_flag_btn_add_post_time.html.erb
@@ -1,10 +1,10 @@
 <td >
-  <% if tweet.retweet_flag? %>
+  <% if @tweet.retweet_flag? %>
     <button class="btn btn-info m-2 flag-btn-add-date" disabled>
       最新リツイート &emsp; <%= again_post_date(@tweet.retweets) %>
     </button>
   <% end %>
-  <% if tweet.tweet_flag? %>
+  <% if @tweet.tweet_flag? %>
     <button class="btn btn-warning m-2 flag-btn-add-date" disabled>
       最新再投稿 &emsp; <%= again_post_date(@tweet.reposts) %>
     </button>

--- a/app/views/tweets/_flag_btn_add_post_time.html.erb
+++ b/app/views/tweets/_flag_btn_add_post_time.html.erb
@@ -1,10 +1,10 @@
 <td >
-  <% if @tweet.retweet_flag? %>
+  <% if @tweet.retweet_flag? && @tweet.retweets.present? %>
     <button class="btn btn-info m-2 flag-btn-add-date" disabled>
       最新リツイート &emsp; <%= again_post_date(@tweet.retweets) %>
     </button>
   <% end %>
-  <% if @tweet.tweet_flag? %>
+  <% if @tweet.tweet_flag? && @tweet.reposts.present? %>
     <button class="btn btn-warning m-2 flag-btn-add-date" disabled>
       最新再投稿 &emsp; <%= again_post_date(@tweet.reposts) %>
     </button>

--- a/app/views/tweets/_retweet_modal.html.erb
+++ b/app/views/tweets/_retweet_modal.html.erb
@@ -27,7 +27,8 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-          <%= f.hidden_field :tweet_id, value: @tweet.tweet_id %>
+          <%= f.hidden_field :tweet_string_id, value: @tweet.tweet_string_id %>
+          <%= f.hidden_field :id, value: @tweet.id %>
           <%= f.submit "リツイートする", class: "btn btn-primary" %>
         </div>
       <% end %>

--- a/app/views/tweets/_tweet_modal.html.erb
+++ b/app/views/tweets/_tweet_modal.html.erb
@@ -23,7 +23,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-          <%= f.hidden_field :tweet_id, value: @tweet.tweet_id %>
+          <%= f.hidden_field :tweet_string_id, value: @tweet.tweet_string_id %>
           <%= f.submit "再投稿する", class: "btn btn-primary" %>
         </div>
       <% end %>

--- a/app/views/tweets/show.html.erb
+++ b/app/views/tweets/show.html.erb
@@ -5,7 +5,7 @@
   <tbody >
     <tr>
       <th scope="col">再投稿の状態</th>
-        <%= render partial: 'flag_btn', locals: { tweet: @tweet }%>
+        <%= render partial: 'flag_btn_add_post_time', locals: { tweet: @tweet }%>
     </tr>
     <tr>
       <th scope="col">投稿日時</th>

--- a/db/migrate/20201225135203_rename_tweet_id_column_to_tweets.rb
+++ b/db/migrate/20201225135203_rename_tweet_id_column_to_tweets.rb
@@ -1,0 +1,5 @@
+class RenameTweetIdColumnToTweets < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :tweets, :tweet_id, :tweet_string_id
+  end
+end

--- a/db/migrate/20201225224517_create_reposts.rb
+++ b/db/migrate/20201225224517_create_reposts.rb
@@ -1,0 +1,8 @@
+class CreateReposts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :reposts do |t|
+      t.references :tweet, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201225224613_create_retweets.rb
+++ b/db/migrate/20201225224613_create_retweets.rb
@@ -1,0 +1,8 @@
+class CreateRetweets < ActiveRecord::Migration[6.0]
+  def change
+    create_table :retweets do |t|
+      t.references :tweet, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_25_135203) do
+ActiveRecord::Schema.define(version: 2020_12_25_224613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,20 @@ ActiveRecord::Schema.define(version: 2020_12_25_135203) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["tweet_id"], name: "index_media_on_tweet_id"
+  end
+
+  create_table "reposts", force: :cascade do |t|
+    t.bigint "tweet_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["tweet_id"], name: "index_reposts_on_tweet_id"
+  end
+
+  create_table "retweets", force: :cascade do |t|
+    t.bigint "tweet_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["tweet_id"], name: "index_retweets_on_tweet_id"
   end
 
   create_table "tweets", force: :cascade do |t|
@@ -52,5 +66,7 @@ ActiveRecord::Schema.define(version: 2020_12_25_135203) do
   end
 
   add_foreign_key "media", "tweets"
+  add_foreign_key "reposts", "tweets"
+  add_foreign_key "retweets", "tweets"
   add_foreign_key "tweets", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_10_132308) do
+ActiveRecord::Schema.define(version: 2020_12_25_135203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 2020_12_10_132308) do
 
   create_table "tweets", force: :cascade do |t|
     t.datetime "tweet_created_at", null: false
-    t.string "tweet_id", null: false
+    t.string "tweet_string_id", null: false
     t.string "text", null: false
     t.integer "retweet_count", null: false
     t.integer "favorite_count", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,7 @@ end
 10.times do |n|
   Tweet.create!(
     tweet_created_at: "Sat, 21 Nov 2020 02:28:09 UTC +00:00",
-    tweet_id:"123456789",
+    tweet_string_id:"123456789",
     text: "こんにちは#{n + 1}",
     retweet_count: n+1,
     favorite_count: n+1,
@@ -19,7 +19,7 @@ end
 
 # 10.times do |n|
 #   Medium.create!(
-#     tweet_id: n+1,
+#     tweet_string_id: n+1,
 #     media_url: File.open('./app/assets/images/sample.png')
 #   )
 # end 

--- a/spec/factories/reposts.rb
+++ b/spec/factories/reposts.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :repost do
+    
+  end
+end

--- a/spec/factories/reposts.rb
+++ b/spec/factories/reposts.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :repost do
-    
+    tweet_id { 123 }
   end
 end

--- a/spec/factories/retweets.rb
+++ b/spec/factories/retweets.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :retweet do
+    
+  end
+end

--- a/spec/factories/retweets.rb
+++ b/spec/factories/retweets.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :retweet do
-    
+    tweet_id { 123 }
   end
 end

--- a/spec/models/repost_spec.rb
+++ b/spec/models/repost_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Repost, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/repost_spec.rb
+++ b/spec/models/repost_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Repost, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/models/retweet_spec.rb
+++ b/spec/models/retweet_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Retweet, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/retweet_spec.rb
+++ b/spec/models/retweet_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Retweet, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"


### PR DESCRIPTION
closes #67 

## 目的・概要
<!--  プルリクエストの目的・概要を記載  -->
いつ再投稿、リツイートしたかをユーザ側が認識できるようにする。

## 実装内容
<!-- 実装の技術的な内容を箇条書きで記載 -->
- 再投稿、リツイート日時を格納するRepost, Retweetモデル作成
- 再投稿、リツイートしたタイミングでモデルへデータを格納。格納した最新の日付をview画面にも表示

## UI変更概要
<!-- UIの変更内容を大まかに記載 -->
- ツイート詳細画面「再投稿済」「リツイート済」ボタンから、「最新リツイート　YY年MM月DD日」「最新再投稿　YY年MM月DD日」と表示する。

### 画面キャプチャ
<!-- UIの変更後の画像を入れる（UIに変更があった場合） -->
<img width="1264" alt="date" src="https://user-images.githubusercontent.com/35606852/103143493-6f9b2780-475a-11eb-9c1d-cfdb623fe42d.png">

## 稼働確認チェック
- [x] ローカル環境での動作確認
- [x] rspecの実行＆エラーなし
- [x] rubocopの実行＆コード修正

## 参考資料

## 連絡事項
<!-- 本プルリク反映後に運用変更が必要になる場合など記載 -->
tweetsテーブルのカラム
`tweet_id`から`tweet_string_id`に変更、該当コード修正
ツイート取得、再投稿、リツイート動作確認しています。
