### PR TITLE
ツイート全文取得機能実装

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -75,7 +75,7 @@ class TweetsController < ApplicationController
     end
 
     def create_tweet_record(res)
-      Tweet.create!(
+      tweet = Tweet.create!(
         user_id: current_user.id,
         tweet_created_at: res["created_at"],
         tweet_id: res["id_str"],
@@ -83,6 +83,7 @@ class TweetsController < ApplicationController
         retweet_count: res["retweet_count"],
         favorite_count: res["favorite_count"]
       )
+      tweet.update(text: res["extended_tweet"]["full_text"]) if res["extended_tweet"].present?
     end
 
     def update_tweet_record(tweet, res)


### PR DESCRIPTION
closes #58 

## 目的・概要
<!--  プルリクエストの目的・概要を記載  -->
詳細画面に表示されるツイートの文字数が多い場合、「...」で省略されていた。
ツイート全文を取得できるように修正

## 実装内容
<!-- 実装の技術的な内容を箇条書きで記載 -->
- ["extended_tweet"]パラメータがある場合、textカラムを["text"]から["extended_tweet"]の値に上書き


## 稼働確認チェック
- [x] ローカル環境での動作確認
- [x] rspecの実行＆エラーなし
- [x] rubocopの実行＆コード修正

## 参考資料


## 連絡事項
<!-- 本プルリク反映後に運用変更が必要になる場合など記載 -->
- Tweetテーブルのtextカラム格納方法を迷いました。
1. tweetsテーブルのtext以外のカラムを事前にcreate
   ➡︎その後、updateにて["extended_tweet"]がある場合は["extended_tweet"]、無い場合は["text"]をカラムに追加
2. create時点では["text"]をカラムに格納。その後、updateにて["extended_tweet"]がある場合は["extended_tweet"]を上書き

今回は、2にて実装しています。（createする際に"text"が入ってないとバリデーションエラーが発生したため）
何か不都合がある場合は、教えていただけると助かります。
