### PR TITLE
戻るボタン実装

### DIFF
--- a/app/views/tweets/show.html.erb
+++ b/app/views/tweets/show.html.erb
@@ -1,7 +1,7 @@
 
 <h2 class="text-center mt-5 mb-3">ツイートの詳細</h2>
 <%= render 'flash' %>
-<table class="table table-bordered  my-5 mx-auto table-show ">
+<table class="table table-bordered  mt-5 mx-auto table-show ">
   <tbody >
     <tr>
       <th scope="col">再投稿の状態</th>
@@ -25,7 +25,7 @@
     <%= render partial: 'show_column', locals: { heading: "いいね数",column_data: @tweet.favorite_count}%>
   </tbody>
 </table>
-
+<div class="text-right my-3 h6 " style="width:90%;" ><%= link_to 'ツイートの一覧へ戻る', 'javascript:history.back()',class:" text-muted"%></div>
  <div class="text-center ">
 
    <button type="button" class="btn btn-warning mx-2 method-btn" data-toggle="modal" data-target="#modal2" value=@tweet>
@@ -39,4 +39,3 @@
 
  </div>
 
-<div class="nozomi"></div>


### PR DESCRIPTION
 closes #77 
## 目的・概要
<!--  プルリクエストの目的・概要を記載  -->
- 現状、ツイート詳細画面から一覧画面へ戻るボタンがないので追加する。
- 一覧画面に検索条件とページネーションが維持された状態で戻す
## 実装内容
<!-- 実装の技術的な内容を箇条書きで記載 -->
- 一覧画面へ戻るボタン実装


## UI変更概要
<!-- UIの変更内容を大まかに記載 -->
- 戻るボタンを詳細画面テーブル右下に実装

### 画面キャプチャ
<!-- UIの変更後の画像を入れる（UIに変更があった場合） -->
<img width="954" alt="スクリーンショット 2021-01-11 10 37 12" src="https://user-images.githubusercontent.com/67478234/104141252-281ec780-53f9-11eb-90ce-5bd2c8f6b001.png">

## 稼働確認チェック
- [x] ローカル環境での動作確認
- [x] rspecの実行＆エラーなし
- [x] rubocopの実行＆コード修正

## 参考資料
- [【Rails】戻るボタンの実装方法【複数ページ戻ることも可能】](https://qiita.com/nekojoker/items/cb662de7cbb65e438985)

## 連絡事項
<!-- 本プルリク反映後に運用変更が必要になる場合など記載 -->
バグ修正のブランチをマージしていないため、テストでエラーが出ています。