### PR TITLE
リツイート全数取得

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -99,7 +99,7 @@ class TweetsController < ApplicationController
         tweet_created_at: res["created_at"],
         tweet_string_id: res["id_str"],
         text: res["text"],
-        retweet_count: res["retweet_count"],
+        retweet_count: all_retweet_count(res),
         favorite_count: res["favorite_count"]
       )
       tweet.update(text: res["extended_tweet"]["full_text"]) if res["extended_tweet"].present?
@@ -107,7 +107,7 @@ class TweetsController < ApplicationController
 
     def update_tweet_record(tweet, res)
       tweet.update(
-        retweet_count: res["retweet_count"],
+        retweet_count: all_retweet_count(res),
         favorite_count: res["favorite_count"]
       )
     end
@@ -156,12 +156,15 @@ class TweetsController < ApplicationController
 
     def error_status?(res_status)
       !!if res_status[:code] != "200"
-          # flash[:alert] = "以下の理由でツイートを取得できませんでした。#{res_status[:message]}"
           redirect_to new_tweet_path, danger: "以下の理由でツイートを取得できませんでした。#{res_status[:message]}"
         end
     end
 
     def sort_params
       params.require(:q).permit(:sorts)
+    end
+
+    def all_retweet_count(res)
+      res["retweet_count"] + res["quote_count"]
     end
 end

--- a/app/lib/twitter_api.rb
+++ b/app/lib/twitter_api.rb
@@ -28,7 +28,7 @@ module TwitterApi
 
   def post_retweet(params_retweet, login_user)
     client = twitter_client(login_user)
-    old_tweet_url = "https://twitter.com/#{login_user.nickname}/status/#{params_retweet[:tweet_id]}"
+    old_tweet_url = "https://twitter.com/#{login_user.nickname}/status/#{params_retweet[:tweet_string_id]}"
     client.update("#{params_retweet[:add_comments]}  #{old_tweet_url}")
   end
 


### PR DESCRIPTION
closes #80

## 目的・概要
<!--  プルリクエストの目的・概要を記載  -->
リツイート表記件数が正常な場合と異常な場合があったため、調査、修正

## 原因
動作確認にて、コメントなしのリツイート件数しか加算されていないことが判明。
Twitter内でもコメント有り、無しの引用リツイートはそれぞれ別々のものとしてカウントされていたため

## 実装内容
<!-- 実装の技術的な内容を箇条書きで記載 -->
 retweet_count : コメント無しリツイート数
 quote_count : コメント有りリツイート数

- ツイート取得時、今までの`retweet_count`に`quote_count`を加算した値をtweetsテーブルの`retweet_count`パラメータに入れることで解消

## UI変更概要
<!-- UIの変更内容を大まかに記載 -->


### 画面キャプチャ
<!-- UIの変更後の画像を入れる（UIに変更があった場合） -->

## 稼働確認チェック
- [x] ローカル環境での動作確認
- [x] rspecの実行＆エラーなし
- [x] rubocopの実行＆コード修正

## 参考資料
- [search api レスポンスパラメータ](https://developer.twitter.com/en/docs/twitter-api/premium/data-dictionary/object-model/tweet
)
## 連絡事項
<!-- 本プルリク反映後に運用変更が必要になる場合など記載 -->
- その他修正
このサービスからリツイートした際に、元ツイートのリンクが異常だったため、`twitter_api.rb`内の
`old_tweet_url = "https://twitter.com/#{login_user.nickname}/status/#{params_retweet[:tweet_id]}"`
の`#{params_retweet[:tweet_id]`を`#{params_retweet[:tweet_string_id]`に修正