### PR TITLE
ストロングパラメータ使用時のunpermitted parametersを非表示にする

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -150,6 +150,7 @@ class TweetsController < ApplicationController
     end
 
     def params_retweet
+      binding.pry
       params.require(:tweet).permit(:add_comments, :tweet_string_id)
     end
 

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -150,7 +150,6 @@ class TweetsController < ApplicationController
     end
 
     def params_retweet
-      binding.pry
       params.require(:tweet).permit(:add_comments, :tweet_string_id)
     end
 

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -53,7 +53,7 @@ class TweetsController < ApplicationController
   end
 
   def date_params_check
-    return if params.permit(:period).present?
+    return if params.require(:period).present?
 
     redirect_to new_tweet_path, danger: "期間が指定されていません。入力し直してください"
   end
@@ -128,9 +128,8 @@ class TweetsController < ApplicationController
     end
 
     def first_search_params
-      period = JSON.parse(params.require(:period))
-      count = params.permit(:count)
-      conditions = period.merge(count)
+      conditions = JSON.parse(params.require(:period))
+      conditions.store("count", params.require(:count))
       conditions.store("login_user", current_user.nickname)
       conditions
     end

--- a/app/views/tweets/_retweet_modal.html.erb
+++ b/app/views/tweets/_retweet_modal.html.erb
@@ -15,8 +15,10 @@
             <p><%= f.text_area :add_comments, class: "form-control", rows: 4 %></p>
           </div>
           <div class="p-2">
-            <p><%= f.label :label_old_tweet, "元投稿内容" %></p>
-            <p><%= f.text_area :old_tweet, class: "form-control", rows: 4, readonly: true, value: @tweet.text %></p>
+            <p><label>元投稿内容</label></p>
+            <p><textarea class="form-control" rows="4" readonly="true">
+              <%= @tweet.text %>
+            </textarea></p>
           </div>
           <div class="p-2">
             <p><%= f.label :label_show_image, "画像" %></p>
@@ -28,7 +30,6 @@
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
           <%= f.hidden_field :tweet_string_id, value: @tweet.tweet_string_id %>
-          <%= f.hidden_field :id, value: @tweet.id %>
           <%= f.submit "リツイートする", class: "btn btn-primary" %>
         </div>
       <% end %>


### PR DESCRIPTION
closes #54

## 目的・概要
<!--  プルリクエストの目的・概要を記載  -->
ストロングパラメータ使用時のunpermitted parametersを非表示にする
正常稼働はしているが、毎回エラーとして表示されるため改善

## 実装内容
search, retweetにて以下手段を実施
<!-- 実装の技術的な内容を箇条書きで記載 -->
- `params.permit`にて取得していたパラメータを`params.require`によって取得
　（paramsの階層を変更することでunpermitted parametersを防ぐ)
- retweetは、controllerにて使用しない値を`_retweet_modal.html.erb`のform内から削除

## 稼働確認チェック
- [x] ローカル環境での動作確認
- [x] rspecの実行＆エラーなし
- [x] rubocopの実行＆コード修正

## 参考資料
- https://qiita.com/yusabana/items/78e8d1ed64ead5fe9e29

## 連絡事項
<!-- 本プルリク反映後に運用変更が必要になる場合など記載 -->
ツイート取得、リツイート機能のunpermitted parameters表示結果確認お願い致します。
今回、コードの変更はしていませんが、検索、再投稿機能実行の際にも表示されていないこと確認お願いします。