### PR TITLE
タイムラインを表示

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,6 +23,10 @@ table {
 .pagination {
   justify-content: center;
 }
+.time-line {
+  display: block;
+  margin-top: 100px;
+}
 // ツイート表示テーブル
 .table_index{
   // テーブルヘッダーを固定
@@ -172,6 +176,9 @@ table {
   }
 
 // ツイート一覧
+  .time-line{
+    display: none;
+  }
   .table_index {
     width: 100%;
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,12 +13,16 @@ table {
   margin-left: auto;
   margin-right: auto;
   height: auto;
-  
   }
 // ナビゲーションメニュー
 .navbar-dark .navbar-nav .nav-link{
   color: #ffffff;
 }
+// 自動改行防止
+span {
+  display: inline-block;
+}
+
 // ツイート一覧ページ
 .pagination {
   justify-content: center;
@@ -36,9 +40,8 @@ table {
     display: inline-block;
     width: 100%;
   }
-    thead,{
- padding-left:25px;
-
+  thead,{
+    padding-left:50px;
     }
   tbody {
     width: 100%;
@@ -47,7 +50,7 @@ table {
     height: 600px;
   }
   .table-title{
-     width:10%;
+    width: 10%;
   }
   th,
   td {
@@ -62,6 +65,13 @@ table {
   }
   td{
     height: 80px;
+  }
+  th {
+   font-size:0.8rem;
+  
+  }
+  .nowrap {
+    white-space: nowrap
   }
   .text{
     width:30%;
@@ -152,7 +162,12 @@ table {
     padding:10px;
      margin-left:10px;
 }
+@media screen and (max-width: 1024px) {
+.time-line {
+  display: none;
+}
 
+}
 @media screen and (max-width: 768px) {
   .last td:last-child {
     border-bottom: solid 1px #ccc;

--- a/app/views/tweets/index.html.erb
+++ b/app/views/tweets/index.html.erb
@@ -1,8 +1,15 @@
-<div class="container text-center ">
+<div class="text-center ">
 <% if logged_in? %>
+
+<%# 検索ボックス %>
+<div class="row ">
+<% if current_user%>
+  <div class="col-md-3 mx-4 time-line"><a class="twitter-timeline" data-lang="ja" data-height="100%" data-chrome=”noheader,nofooter” href="https://twitter.com/<%= @user.nickname %>?ref_src=twsrc%5Etfw">twitterタイムライン</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></div>
+<% end %>
+
+<div class="col-md-8  mx-auto">
 <h2 class="text-center mt-5 mb-3">ツイートの一覧</h2>
 <%= render 'flash' %>
-<%# 検索ボックス %>
 <h5 class="text-left my-3 search-condition-btn">検索条件<i class="fas fa-plus-circle button"></i></h5>
   <%= search_form_for(@q,url: root_path) do |f| %>
     <table class="table table-bordered table_search ">
@@ -99,9 +106,8 @@
   <%= link_to 'Twitterアカウントでログイン', "/auth/twitter" ,class:"btn btn-primary login_btn m-5" %>
 <% end %>
 </div>
-
-
-
+</div>
+</div>
 <script>
 // 検索テーブルの表示・非表示の切り替え
 var $target = document.querySelector('.table_search ')

--- a/app/views/tweets/index.html.erb
+++ b/app/views/tweets/index.html.erb
@@ -4,10 +4,10 @@
 <%# 検索ボックス %>
 <div class="row ">
 <% if current_user%>
-  <div class="col-md-3 mx-4 time-line"><a class="twitter-timeline" data-lang="ja" data-height="100%" data-chrome=”noheader,nofooter” href="https://twitter.com/<%= @user.nickname %>?ref_src=twsrc%5Etfw">twitterタイムライン</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></div>
+  <div class="col-lg-3  time-line" id="time-line"><a class="twitter-timeline" data-lang="ja" data-height="100%" data-chrome=”noheader,nofooter” href="https://twitter.com/<%= @user.nickname %>?ref_src=twsrc%5Etfw">twitterタイムライン</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></div>
 <% end %>
 
-<div class="col-md-8  mx-auto">
+<div class="col-lg-9 mx-auto">
 <h2 class="text-center mt-5 mb-3">ツイートの一覧</h2>
 <%= render 'flash' %>
 <h5 class="text-left my-3 search-condition-btn">検索条件<i class="fas fa-plus-circle button"></i></h5>
@@ -74,9 +74,9 @@
       <th scope="col"class="table-title"></th>
       <th scope="col"class="day" ><%= sort_link(@q, :tweet_created_at, "投稿日時" ,{ default_order: :desc }, { class: "Editlink sort-link" }) %></th>
       <th scope="col" class="text">投稿内容</th>
-      <th scope="col" class="table-title">投稿画像</th>
-      <th scope="col"class="table-title" ><%= sort_link(@q, :retweet_count, "リツイート", { default_order: :desc }, { class: "Editlink" }) %></th>
-      <th scope="col"class="table-title" ><%= sort_link(@q, :favorite_count, "いいね", { default_order: :desc }, { class: "Editlink" }) %></th>
+      <th scope="col" class="table-title"><span> 投稿</span><span>画像</span>
+      <th scope="col"class="table-title nowrap" ><%= sort_link(@q, :retweet_count, "リツイート", { default_order: :desc }, { class: "Editlink" }) %></th>
+      <th scope="col"class="table-title nowrap " ><%= sort_link(@q, :favorite_count, "いいね", { default_order: :desc }, { class: "Editlink" }) %></th>
       <th scope="col"class="table-title "></th>
     </tr>
     </thead>


### PR DESCRIPTION
closes #92 
## 目的・概要
<!--  プルリクエストの目的・概要を記載  -->
ツイート一覧画面にログインユーザーのタイムラインを表示
## 実装内容
<!-- 実装の技術的な内容を箇条書きで記載 -->
- ツイート一覧画面にログインユーザーのタイムラインを表示
- スマホ時はタイムラインは表示しない

## UI変更概要
<!-- UIの変更内容を大まかに記載 -->



### 画面キャプチャ
<!-- UIの変更後の画像を入れる（UIに変更があった場合） -->
<img width="1440" alt="スクリーンショット 2021-01-18 0 12 53" src="https://user-images.githubusercontent.com/67478234/104847698-13748f00-5925-11eb-8760-df142ecd29b2.png">

## 稼働確認チェック
- [x] ローカル環境での動作確認
- [x] rspecの実行＆エラーなし
- [x] rubocopの実行＆コード修正

## 参考資料

## 連絡事項
<!-- 本プルリク反映後に運用変更が必要になる場合など記載 -->
