### PR TITLE
出力ログレベルの変更（#84継続イシュ）

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -154,9 +154,9 @@ class TweetsController < ApplicationController
       params.require(:tweet).permit(:add_comments, :tweet_string_id)
     end
 
-    def error_status?(res_status)
+    def error_status?(res_status, response)
       !!if res_status[:code] != "200"
-          put_api_error_log("search", status, e)
+          put_api_error_log("search", res_status[:code], response["error"]["message"])
           redirect_to new_tweet_path, danger: "以下の理由でツイートを取得できませんでした。#{res_status[:message]}"
         end
     end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :error
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
@@ -88,8 +88,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-
-  config.log_level = :error
 
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector


### PR DESCRIPTION
closes #96 

## 目的・概要
<!--  プルリクエストの目的・概要を記載  -->
本番環境のログ出力レベル記載が二重となっていたため、修正


## 実装内容
<!-- 実装の技術的な内容を箇条書きで記載 -->
- `config/environments/production.rb`の出力ログレベル　debug から error に修正

- 別途、ツイート検索のログ出力にて不具合があったため修正

## 稼働確認チェック
- [x] ローカル環境での動作確認
- [x] rspecの実行＆エラーなし
- [x] rubocopの実行＆コード修正

## 参考資料
- 

## 連絡事項
<!-- 本プルリク反映後に運用変更が必要になる場合など記載 -->
