### PR TITLE
AutoTweetテーブルへアクセスするrakeタスク作成

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,21 +1,23 @@
-User.find_or_create_by!(nickname: "test") do |user|
-  uid:"123456789",
-  nickname:"test"
-end
+# User.find_or_create_by!(nickname: "test") do |user|
+#   uid:"123456789",
+#   nickname:"test"
+# end
 
 
-3.times do |n|
-  Tweet.create!(
-    tweet_created_at: "Sat, 21 Nov 2019 02:28:09 UTC +00:00",
-    tweet_string_id:"123456789",
-    text: "こんにちは#{n + 1}",
-    retweet_count: n+1,
-    favorite_count: n+1,
-    user_id:2,
-    tweet_flag: true,
-    retweet_flag: false
-  )
-  end
+# 3.times do |n|
+#   Tweet.create!(
+#     tweet_created_at: "Sat, 21 Nov 2019 02:28:09 UTC +00:00",
+#     tweet_string_id:"123456789",
+#     text: "こんにちは#{n + 1}",
+#     retweet_count: n+1,
+#     favorite_count: n+1,
+#     user_id:2,
+#     tweet_flag: true,
+#     retweet_flag: false
+#   )
+#   end
+
+
 
 # 10.times do |n|
 #   Medium.create!(
@@ -23,3 +25,17 @@ end
 #     media_url: File.open('./app/assets/images/sample.png')
 #   )
 # end 
+
+  AutoTweet.create!(
+    user_id:3,
+    tweet_hour1:22,
+    tweet_hour2:23,
+    tweet_hour3:0,
+    tweet_hour4:1,
+    tweet_hour5:2,
+    sort_column:"retweet_count",
+    order:"desc",
+    exclude_tweet:1,
+    exclude_repost:1,
+    count:1,
+  )

--- a/lib/tasks/access_autotweet.rake
+++ b/lib/tasks/access_autotweet.rake
@@ -1,40 +1,35 @@
 require "time"
 namespace :access_autotweet do
   desc "AutoTweetテーブルへアクセスする"
-  task :auto_tweets => :environment do
-    @now=Time.now.hour
-     # 18:58 などにheroku schedulerが起動した際に、3分足すことで時間誤差を修正する
-    @lag=Time.now+(60*3)  
-    @time_lag=@lag.hour
+  task auto_tweets: :environment do
+    @now = Time.zone.now.hour
+    # 18:58 などにheroku schedulerが起動した際に、3分足すことで時間誤差を修正する
+    @lag = Time.zone.now + (60 * 3)
+    @time_lag = @lag.hour
     # Autotweetの時間と今の時間が一致しているか確認
-    @autotweet_first=AutoTweet.where(tweet_hour1:@time_lag)
-    @autotweet_second=AutoTweet.where(tweet_hour2:@time_lag)
-    @autotweet_third=AutoTweet.where(tweet_hour3:@time_lag)
-    @autotweet_fourth=AutoTweet.where(tweet_hour4:@time_lag)
-    @autotweet_fifth=AutoTweet.where(tweet_hour5:@time_lag)
-    @autotweets_array=[@autotweet_first,@autotweet_second,@autotweet_third,@autotweet_fourth,@autotweet_fifth]
+    @autotweet_first = AutoTweet.where(tweet_hour1: @time_lag)
+    @autotweet_second = AutoTweet.where(tweet_hour2: @time_lag)
+    @autotweet_third = AutoTweet.where(tweet_hour3: @time_lag)
+    @autotweet_fourth = AutoTweet.where(tweet_hour4: @time_lag)
+    @autotweet_fifth = AutoTweet.where(tweet_hour5: @time_lag)
+    @autotweets_array = [@autotweet_first, @autotweet_second, @autotweet_third, @autotweet_fourth, @autotweet_fifth]
 
     # 仮設定したメソッド
-    def auto_tweet(user) 
+    def auto_tweet(user)
       puts "auto_tweetメソッドへ引数渡す！"
       puts user.nickname
     end
+
     # auto_tweetを呼び出す
     def call_auto_tweet(autotweets)
-      if autotweets
-       autotweets.each do |autotweet|  
-        @user= User.find_by(id: autotweet.user_id)
+      autotweets&.each do |autotweet|
+        @user = User.find_by(id: autotweet.user_id)
         auto_tweet(@user)
-       end
       end
     end
     # call_auto_tweetを呼び出す
     @autotweets_array.each do |argument|
       call_auto_tweet(argument)
     end
- 
   end
 end
-
-
-

--- a/lib/tasks/access_autotweet.rake
+++ b/lib/tasks/access_autotweet.rake
@@ -1,0 +1,40 @@
+require "time"
+namespace :access_autotweet do
+  desc "AutoTweetテーブルへアクセスする"
+  task :auto_tweets => :environment do
+    @now=Time.now.hour
+     # 18:58 などにheroku schedulerが起動した際に、3分足すことで時間誤差を修正する
+    @lag=Time.now+(60*3)  
+    @time_lag=@lag.hour
+    # Autotweetの時間と今の時間が一致しているか確認
+    @autotweet_first=AutoTweet.where(tweet_hour1:@time_lag)
+    @autotweet_second=AutoTweet.where(tweet_hour2:@time_lag)
+    @autotweet_third=AutoTweet.where(tweet_hour3:@time_lag)
+    @autotweet_fourth=AutoTweet.where(tweet_hour4:@time_lag)
+    @autotweet_fifth=AutoTweet.where(tweet_hour5:@time_lag)
+    @autotweets_array=[@autotweet_first,@autotweet_second,@autotweet_third,@autotweet_fourth,@autotweet_fifth]
+
+    # 仮設定したメソッド
+    def auto_tweet(user) 
+      puts "auto_tweetメソッドへ引数渡す！"
+      puts user.nickname
+    end
+    # auto_tweetを呼び出す
+    def call_auto_tweet(autotweets)
+      if autotweets
+       autotweets.each do |autotweet|  
+        @user= User.find_by(id: autotweet.user_id)
+        auto_tweet(@user)
+       end
+      end
+    end
+    # call_auto_tweetを呼び出す
+    @autotweets_array.each do |argument|
+      call_auto_tweet(argument)
+    end
+ 
+  end
+end
+
+
+


### PR DESCRIPTION
## 目的・概要
<!--  プルリクエストの目的・概要を記載  -->
1時間に1回heroku schedulerが実行される。そのタイミングでrakeタスクにてAutoTweetモデルへアクセスを行う。
## 実装内容
<!-- 実装の技術的な内容を箇条書きで記載 -->
- AutoTweetテーブルへアクセス
- テーブル内のtweet_hourと実行時間のx時が一致する場合、auto_tweetメソッド（仮）を呼び出す
- auto_tweet メソッドの引数としてユーザ情報を渡す
- `Time.zone.now + (60 * 3)`とすることで、(x - 1)時58分、59分にheroku suchedulerが実行された場合にもx時に処理が行われたとして再投稿処理へ移行する、逆に、x時58分、59分に実行された場合は、処理を行わない
- heroku のタイムゾーンを日本に合わせる

## UI変更概要
<!-- UIの変更内容を大まかに記載 -->
- なし

## 稼働確認チェック
- [x] ローカル環境での動作確認
- [x] rspecの実行＆エラーなし
- [x] rubocopの実行＆コード修正

## 参考資料
- [Herokuのタイムゾーンを日本に合わせる](https://qiita.com/ikemura23/items/52ab8a5d260c7ee4d42b)

## 連絡事項
<!-- 本プルリク反映後に運用変更が必要になる場合など記載 -->
各自ローカル環境のAutoTweetテーブルにダミーデータを入れることで、動作確認お願い致します。
タスク実行コマンドは`rake access_autotweet:auto_tweets`です